### PR TITLE
Update forgivingvoid.cfg

### DIFF
--- a/config/forgivingvoid.cfg
+++ b/config/forgivingvoid.cfg
@@ -8,6 +8,7 @@ general {
 
     # List of additional dimension ids to be blacklisted from Forgiving Void. Options triggerInOverworld etc. take priority.
     S:dimensionBlacklist <
+        6
      >
 
     # Set to true if you want the dimensionBlacklist to be treated as a whitelist instead. Options triggerInOverworld etc. still take priority.

--- a/config/forgivingvoid.cfg
+++ b/config/forgivingvoid.cfg
@@ -9,6 +9,8 @@ general {
     # List of additional dimension ids to be blacklisted from Forgiving Void. Options triggerInOverworld etc. take priority.
     S:dimensionBlacklist <
         6
+        9
+        10
      >
 
     # Set to true if you want the dimensionBlacklist to be treated as a whitelist instead. Options triggerInOverworld etc. still take priority.


### PR DESCRIPTION
Adds Limbo dimension to the forgiving void blacklist so it doesn't interfere with dimensionaldoors limbo mechanics