### PR TITLE
Update voidislandcontrol.cfg

### DIFF
--- a/config/voidislandcontrol.cfg
+++ b/config/voidislandcontrol.cfg
@@ -94,7 +94,7 @@ general {
         S:islandMainSpawnType=hosstarter
 
         # Disables effect of protectionBuildRange
-        B:islandProtection=true
+        B:islandProtection=false
 
         # Width of islands
         I:islandSize=20


### PR DESCRIPTION
Turn off the protected build range, we have the islands at 5000 blocks apart and have FTBUtils available for players to claim their region and it interferes with many of the teleport stuff in the pack, following ones are known:
Arcane Worlds Dungeon Return Portal Teleport
Op `/tp` command unless also in creative mode
Dimensional doors teleport to overworld
Ftbutils /tpa for visiting friend on their island